### PR TITLE
feat: add addtional setting to tune client instanciation

### DIFF
--- a/django_elasticsearch/client.py
+++ b/django_elasticsearch/client.py
@@ -5,4 +5,8 @@ from elasticsearch import Elasticsearch
 
 es_client = Elasticsearch(getattr(settings,
                                   'ELASTICSEARCH_URL',
-                                  'http://localhost:9200'))
+                                  'http://localhost:9200'),
+                          **getattr(settings,
+                                   'ELASTICSEARCH_CONNECTION_KWARGS',
+                                   {})
+                         )

--- a/readme.md
+++ b/readme.md
@@ -70,6 +70,10 @@ If set, will be passed when creating any index [as is](http://www.elasticsearch.
 defaults to 0.5  
 Will be applied to any es.search query, See the [fuzziness section](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/common-options.html#fuzziness) of the elasticsearch documentation.
 
+**ELASTICSEARCH_CONNECTION_KWARGS**
+defaults to {}
+Additional kwargs to be passed to at the instanciation of the elasticsearch client. Useful to manage HTTPS connection for example. ([Reference](http://elasticsearch-py.readthedocs.org/en/master/api.html#elasticsearch.Elasticsearch))
+
 Model scope configuration:
 --------------------------
 


### PR DESCRIPTION
Useful for managing HTTPS connections.
Ref : http://elasticsearch-py.readthedocs.org/en/master/api.html#elasticsearch

For example:
```
ELASTICSEARCH_URL = "https://search.mydomain.com:443"
ELASTICSEARCH_CONNECTION_KWARGS = { 'use_ssl': True, ca_certs='/path/to/CA_certs'}
```