### PR TITLE
Fix for https://github.com/liberation/django-elasticsearch/issues/35

### DIFF
--- a/django_elasticsearch/query.py
+++ b/django_elasticsearch/query.py
@@ -48,6 +48,11 @@ class EsQueryset(QuerySet):
         self._result_cache = []  # store
         self._total = None
 
+        # fix for https://github.com/liberation/django-elasticsearch/issues/35
+        self._prefetch_related_lookups = []
+        self._prefetch_done = False
+        self._known_related_objects = {}
+
     def __deepcopy__(self, memo):
         """
         Deep copy of a QuerySet doesn't populate the cache


### PR DESCRIPTION
Contributing this fix so others don't run into this issue, shouldn't really break anything since it mirrors the behavior of the parent QuerySet.  Not fully tested yet, will update once we have more tests run on this.