### PR TITLE
py3 compatibility of basestring checks

### DIFF
--- a/django_elasticsearch/managers.py
+++ b/django_elasticsearch/managers.py
@@ -11,6 +11,12 @@ from django.db.models import FieldDoesNotExist
 from django_elasticsearch.query import EsQueryset
 from django_elasticsearch.client import es_client
 
+
+try:
+  basestring #py2
+except NameError:
+  basestring = str #py3
+
 # Note: we use long/double because different db backends
 # could store different sizes of numerics ?
 # Note: everything else is mapped to a string

--- a/django_elasticsearch/tests/test_serializer.py
+++ b/django_elasticsearch/tests/test_serializer.py
@@ -10,6 +10,11 @@ from test_app.models import Dummy
 from test_app.models import Test2Model
 
 
+try:
+  basestring #py2
+except NameError:
+  basestring = str #py3
+
 class CustomSerializer(EsJsonSerializer):
     def serialize_char(self, instance, field_name):
         return u'FOO'


### PR DESCRIPTION
aliased ‘basestring’ with ‘str’ for py3 compatibility